### PR TITLE
Register error handlers after application routes

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -32,17 +32,14 @@ $app = $applicationInitializer->initialize();
 
 // Set the default services
 $defaultServices = new Synapse\Application\Services;
-
 $defaultServices->register($app);
 
 // Set the application-specific  services
 $appServices = new Application\Services;
-
 $appServices->register($app);
 
 // Set the default routes
-$defaultRoutes   = new Synapse\Application\Routes;
-
+$defaultRoutes = new Synapse\Application\Routes;
 $defaultRoutes->define($app);
 
 // Run the application

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -30,17 +30,20 @@ $applicationInitializer = new Synapse\ApplicationInitializer;
 
 $app = $applicationInitializer->initialize();
 
-// Set the default routes and services
-$defaultRoutes   = new Synapse\Application\Routes;
+// Set the and services
 $defaultServices = new Synapse\Application\Services;
 
-$defaultRoutes->define($app);
 $defaultServices->register($app);
 
 // Set the application-specific  services
 $appServices = new Application\Services;
 
 $appServices->register($app);
+
+// Set the default routes
+$defaultRoutes   = new Synapse\Application\Routes;
+
+$defaultRoutes->define($app);
 
 // Run the application
 $app->run();

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -30,7 +30,7 @@ $applicationInitializer = new Synapse\ApplicationInitializer;
 
 $app = $applicationInitializer->initialize();
 
-// Set the and services
+// Set the default services
 $defaultServices = new Synapse\Application\Services;
 
 $defaultServices->register($app);


### PR DESCRIPTION
## Register error handlers after application routes
By defining error handlers last it gives us the opportunity to register  our own error handlers in our service providers to intercept and perform actions in the event of errors. The main use case for this is for customized logging for api access failures.

### Acceptance Criteria
1. In bootstrap the default routes will be registered after the app services