### PR TITLE
Change methods to endpoints in lively config files

### DIFF
--- a/docs/config/application/oauth.js
+++ b/docs/config/application/oauth.js
@@ -1,9 +1,9 @@
 'use strict';
 
 module.exports = {
-    name     : 'OAuth Resources',
-    synopsis : '',
-    methods  : [
+    name      : 'OAuth Resources',
+    synopsis  : '',
+    endpoints : [
         {
             name     : 'Authorize',
             synopsis : 'Authorize via OAuth',

--- a/docs/config/application/users.js
+++ b/docs/config/application/users.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-    name    : 'Users',
-    methods : [
+    name      : 'Users',
+    endpoints : [
         {
             name     : 'Create User',
             synopsis : 'Create a user',


### PR DESCRIPTION
## Change methods to endpoints in lively config files
https://github.com/synapsestudios/lively/pull/107 renamed `methods` to `endpoints` in the lively config files. `methods` will be deprecated at some point, so this change is to update them in the template.

### Acceptance Criteria
1. Lively works as expected.
